### PR TITLE
Support parsing multiple items per line; add test case for unbroken line

### DIFF
--- a/examples/eBons_txt_anonymized/7.txt
+++ b/examples/eBons_txt_anonymized/7.txt
@@ -1,0 +1,16 @@
+[HEADER REDACTED]
+EUR
+BIO HACK SW RD 12,38 B
+2 Stk x 6,19
+PFAND 0,25 EURO 0,25 A *
+ZITRONENSAFT 30,59 A
+ODOL ZAHNCREME 1,39 A
+CREMESEIFE 0,65 AMitarbeiterrabatt5% -0,82 A
+Mitarbeiterrabatt5% -5,06 B
+--------------------------------------
+SUMME EUR 39,38
+======================================
+Geg. American Express EUR 39,38
+* * Kundenbeleg * *
+[PAYMENT DETAILS REDACTED]
+[TSE DATA REDACTED]

--- a/tests/test_item_counting.py
+++ b/tests/test_item_counting.py
@@ -23,6 +23,7 @@ TXT_CASES = [
     ('4.txt', 'txt', 8), # test special characters handling
     ('5.txt', 'txt', 24), # test rewe bonus receipt 1
     ('6.txt', 'txt', 8),  # test rewe bonus receipt 2
+    ('7.txt', 'txt', 7),  # test unbroken line
 ]
 
 # Combine all test cases for the parameterizer (gracefully handle undefined lists)


### PR DESCRIPTION
This pull request improves the parsing logic for receipt items in the `parse.py` module, enhancing support for lines with multiple items and unbroken item lines. It also adds a new test case for this scenario and fixes a minor typo in a regular expression. These changes make the parser more robust and better able to handle real-world receipt formats.

### Parsing improvements

* Updated the `_process_item_line` function in both `parse_ebon` and `parse_text_ebon` to support parsing multiple items from a single line, handling cases where item definitions are merged together. The new logic uses `re.finditer` to extract all items and their associated prices, categories, and loyalty program flags, improving robustness for unbroken or merged item lines. [[1]](diffhunk://#diff-b85b139a5271d1579d6adcd7bd998ec5858464010bf152bc359c25626e6a084dL155-R155) [[2]](diffhunk://#diff-b85b139a5271d1579d6adcd7bd998ec5858464010bf152bc359c25626e6a084dR178-R218) [[3]](diffhunk://#diff-b85b139a5271d1579d6adcd7bd998ec5858464010bf152bc359c25626e6a084dL525-R549) [[4]](diffhunk://#diff-b85b139a5271d1579d6adcd7bd998ec5858464010bf152bc359c25626e6a084dR572-R612)
* Ensured that quantity/weight lines are processed first and that the function returns immediately after handling them, preventing accidental misparsing. [[1]](diffhunk://#diff-b85b139a5271d1579d6adcd7bd998ec5858464010bf152bc359c25626e6a084dR178-R218) [[2]](diffhunk://#diff-b85b139a5271d1579d6adcd7bd998ec5858464010bf152bc359c25626e6a084dR572-R612)

### Test coverage

* Added a new example receipt file `7.txt` and corresponding test case to verify correct item counting and parsing for receipts with unbroken lines or merged items. [[1]](diffhunk://#diff-ac8ba25d8fea7decc01d0e9e014989833942a1097d9eaab7dbc105f969283e30R1-R16) [[2]](diffhunk://#diff-57968fbdc55bf6de802afe5d9bc16fca6fcb769c6e12ca578b5c35d97dde2404R26)

### Bug fixes

* Fixed a typo in the regular expression for detecting "Bonus-Guthaben" lines in the `_process_non_item_line` function, correcting it to "Bonus-Guhaben" for accurate coupon detection.